### PR TITLE
🔧 Move jfrog cli binary to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM debian
 RUN apt-get update && \
     apt-get install -y ca-certificates
 
-ADD 'https://bintray.com/jfrog/jfrog-cli-go/download_file?file_path=1.20.1%2Fjfrog-cli-linux-amd64%2Fjfrog' /jfrog
+ADD 'https://bintray.com/jfrog/jfrog-cli-go/download_file?file_path=1.20.1%2Fjfrog-cli-linux-amd64%2Fjfrog' /usr/local/bin/jfrog
 
-RUN chmod +x /jfrog
+RUN chmod +x /usr/local/bin/jfrog
 
-ENTRYPOINT /jfrog
+ENTRYPOINT /usr/local/bin/jfrog


### PR DESCRIPTION
Move the jfrog cli binary to a directory that is on the `PATH` so that containers which use a different entrypoint (i.e. a shell) may still invoke the tool easily